### PR TITLE
import tabs as discarded

### DIFF
--- a/src/js/backup.js
+++ b/src/js/backup.js
@@ -73,6 +73,7 @@ async function openBackup(data) {
 			var tab = await browser.tabs.create({
 				url: data.windows[wi].tabs[ti].url,
 				active: false,
+				discarded: true,
 				windowId: window.id,
 			}).catch((err) => { console.log(err); });
 

--- a/src/options.html
+++ b/src/options.html
@@ -44,8 +44,7 @@
 			<h2>Backups</h2>
 			<h3>Import</h3>
 			<p>Imported backups will open in new windows and not overwrite anything.<br>You can also import backups from the old "Tab Groups" add-on.</p>
-			<p style="color: red;"><strong>WARNING! This will load all tabs and windows at the same time! This can take a long time.</strong></p>
-			<p><input id="backupFileInput" name="backupFile" type="file" accept=".json" title="This will come once Firefox supports opening a tabs as unloaded."></p>
+			<p><input id="backupFileInput" name="backupFile" type="file" accept=".json"></p>
 			<h3>Export</h3>
 			<p>This section might be made obsolete once proper session management is possible in Firefox.</p>
 			<p><button id="saveBackupButton">Save backup</button></p>


### PR DESCRIPTION
Firefox 63 now supports discarded property when creating tabs.
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/create#Parameters