### PR TITLE
convertBackup: ignore unsupported pinned tabs

### DIFF
--- a/src/js/backup.js
+++ b/src/js/backup.js
@@ -27,15 +27,19 @@ function convertBackup(tgData) {
 		for(const ti in tgData.windows[wi].tabs) {
 
 			var tab = tgData.windows[wi].tabs[ti];
-
-			data.windows[wi].tabs.push({
-				url: tab.entries[0].url,
-				title: tab.entries[0].title,
-				groupId: JSON.parse(tab.extData['tabview-tab']).groupID,
-				index: Number(ti),
-				lastAccessed: tab.lastAccessed,
-				pinned: false,
-			});
+			// Pinned tabs have no extData --> ignore them right now
+			if(tab.extData['tabview-tab'] == 'null' || typeof tab.extData['tabview-tab'] == "undefined") {
+				continue;
+			}else{
+				data.windows[wi].tabs.push({
+					url: tab.entries[0].url,
+					title: tab.entries[0].title,
+					groupId: JSON.parse(tab.extData['tabview-tab']).groupID,
+					index: Number(ti),
+					lastAccessed: tab.lastAccessed,
+					pinned: false,
+				});
+			}
 		}
 	}
 

--- a/src/options.html
+++ b/src/options.html
@@ -44,6 +44,7 @@
 			<h2>Backups</h2>
 			<h3>Import</h3>
 			<p>Imported backups will open in new windows and not overwrite anything.<br>You can also import backups from the old "Tab Groups" add-on.</p>
+			<p style="color: red;"><strong>WARNING! Pinned Tabs are ignored right now, because they are not supported.</strong></p>
 			<p><input id="backupFileInput" name="backupFile" type="file" accept=".json"></p>
 			<h3>Export</h3>
 			<p>This section might be made obsolete once proper session management is possible in Firefox.</p>


### PR DESCRIPTION
Couldn't load my backupfiles from Tab-Groups because of pinned tabs.