### PR TITLE
Add Version "V" to release tag URL

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -351,7 +351,7 @@ function onRuntimeInstallNotification(details) {
 	// Open new tab to the release notes after update
   if (details.reason = 'update') {
     browser.tabs.create({
-      url: `https://github.com/projectdelphai/panorama-tab-groups/releases/tag/${manifest.version}`
+      url: `https://github.com/projectdelphai/panorama-tab-groups/releases/tag/V${manifest.version}`
     });
   }
 }


### PR DESCRIPTION
Since you prepend a V to the release-version it have to be added to opening URL too.

Previous URL:
https://github.com/projectdelphai/panorama-tab-groups/releases/tag/0.8.7

New URL:
https://github.com/projectdelphai/panorama-tab-groups/releases/tag/V0.8.7