### PR TITLE
PT-BR locale

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -3,102 +3,102 @@
         "message": "1"
     },
     "newGroupButton": {
-        "message": "Add new group"
+        "message": "Adicionar novo grupo"
     },
     "settingsButton": {
-        "message": "Settings"
+        "message": "Configurações"
     },
     "defaultGroupName": {
-        "message": "Unnamed group"
+        "message": "Grupo sem nome"
     },
     "dragGroup": {
-        "message": "Drag group"
+        "message": "Mover grupo"
     },
     "closeGroup": {
-        "message": "Close group"
+        "message": "Fechar grupo"
     },
     "closeGroupWarning": {
-        "message": "Closing this group will close the $1 tab within it. Are you sure you want to do this?|Closing this group will close the $1 tabs within it. Are you sure you want to do this?"
+        "message": "Fechar este grupo também fechará a aba $1. Tem certeza que deseja fechá-lo?|Fechar este grupo também fechará as abas $1. Tem certeza que deseja fechá-lo?"
     },
     "optionKeyboardShortcuts": {
-        "message": "Keyboard Shortcuts"
+        "message": "Atalhos de teclado"
     },
     "optionKeyboardShortcutsHelpLink": {
         "message": "https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#Key_combinations"
     },
     "optionKeyboardShortcutsHelpLinkText": {
-        "message": "The format for the shortcut option is detailed here."
+        "message": "A formatação dos atalhos de teclado estão detalhadas aqui."
     },
     "optionKeyboardShortcutsButtonsUpdate": {
-        "message": "Update"
+        "message": "Atualizar"
     },
     "optionKeyboardShortcutsButtonsReset": {
-        "message": "Reset"
+        "message": "Redefinir"
     },
     "optionKeyboardShortcutsToggle": {
-        "message": "Toggle Panorama View"
+        "message": "Alternar visão de panorama"
     },
     "optionKeyboardShortcutsNextGroup": {
-        "message": "Activate the next Tab Group"
+        "message": "Ativar o próximo Grupo de Abas"
     },
     "optionKeyboardShortcutsPreviousGroup": {
-        "message": "Activate the previous Tab Group"
+        "message": "Ativar o Grupo de Abas anterior"
     },
     "optionsTheme": {
-        "message": "Theme"
+        "message": "Tema"
     },
     "optionsThemeLight": {
-        "message": "light"
+        "message": "claro"
     },
     "optionsThemeDark": {
-        "message": "dark"
+        "message": "escuro"
     },
     "optionsToolbar": {
-        "message": "Toolbar"
+        "message": "Barra de tarefas"
     },
     "optionsToolbarPosition": {
-        "message": "Position"
+        "message": "Posição"
     },
     "optionsToolbarPositionTop": {
-        "message": "top"
+        "message": "topo"
     },
     "optionsToolbarPositionRight": {
-        "message": "right"
+        "message": "direita"
     },
     "optionsToolbarPositionBottom": {
-        "message": "bottom"
+        "message": "baixo"
     },
     "optionsToolbarPositionLeft": {
-        "message": "left"
+        "message": "esquerda"
     },
     "optionsBackup": {
-        "message": "Backup"
+        "message": "Cópia de segurança"
     },
     "optionsBackupImport": {
-        "message": "Import"
+        "message": "Importar"
     },
     "optionsBackupImportText": {
-        "message": "Imported backups will open in new windows and not overwrite anything.<br />You can also import backups from the old \"Tab Groups\" add-on."
+        "message": "Cópias de segurança importadas abrirão em novas janelas e não substituirão nada.<br />Você também pode importar cópias de segurança da antiga extensão \"Grupos de Abas\"."
     },
     "optionsBackupExport": {
-        "message": "Export"
+        "message": "Exportar"
     },
     "optionsBackupExportText": {
-        "message": "This section might be made obsolete once proper session management is possible in Firefox."
+        "message": "Esta seção pode se tornar obsoleta, assim que um adequado gerenciamento de sessões esteja disponível no Firefox."
     },
     "optionsBackupExportButton": {
-        "message": "Save backup"
+        "message": "Fazer cópia de segurança"
     },
     "optionsStatistics": {
-        "message": "Statistics"
+        "message": "Estatísticas"
     },
     "optionsStatisticsNumberOfTabs": {
-        "message": "Number of Tabs:"
+        "message": "Número de abas:"
     },
     "optionsStatisticsNumberOfTabsActive": {
-        "message": "Active:"
+        "message": "Ativas:"
     },
     "optionsStatisticsThumbnailCacheSize": {
-        "message": "Thumbnail Cache Size:"
+        "message": "Espaço em disco das minuaturas:"
     }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -3,102 +3,102 @@
         "message": "1"
     },
     "newGroupButton": {
-        "message": "Adicionar novo grupo"
+        "message": "Add new group"
     },
     "settingsButton": {
-        "message": "Configurações"
+        "message": "Settings"
     },
     "defaultGroupName": {
-        "message": "Grupo sem nome"
+        "message": "Unnamed group"
     },
     "dragGroup": {
-        "message": "Mover grupo"
+        "message": "Drag group"
     },
     "closeGroup": {
-        "message": "Fechar grupo"
+        "message": "Close group"
     },
     "closeGroupWarning": {
-        "message": "Fechar este grupo também fechará a aba $1. Tem certeza que deseja fechá-lo?|Fechar este grupo também fechará as abas $1. Tem certeza que deseja fechá-lo?"
+        "message": "Closing this group will close the $1 tab within it. Are you sure you want to do this?|Closing this group will close the $1 tabs within it. Are you sure you want to do this?"
     },
     "optionKeyboardShortcuts": {
-        "message": "Atalhos de teclado"
+        "message": "Keyboard Shortcuts"
     },
     "optionKeyboardShortcutsHelpLink": {
         "message": "https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#Key_combinations"
     },
     "optionKeyboardShortcutsHelpLinkText": {
-        "message": "A formatação dos atalhos de teclado estão detalhadas aqui."
+        "message": "The format for the shortcut option is detailed here."
     },
     "optionKeyboardShortcutsButtonsUpdate": {
-        "message": "Atualizar"
+        "message": "Update"
     },
     "optionKeyboardShortcutsButtonsReset": {
-        "message": "Redefinir"
+        "message": "Reset"
     },
     "optionKeyboardShortcutsToggle": {
-        "message": "Alternar visão de panorama"
+        "message": "Toggle Panorama View"
     },
     "optionKeyboardShortcutsNextGroup": {
-        "message": "Ativar o próximo Grupo de Abas"
+        "message": "Activate the next Tab Group"
     },
     "optionKeyboardShortcutsPreviousGroup": {
-        "message": "Ativar o Grupo de Abas anterior"
+        "message": "Activate the previous Tab Group"
     },
     "optionsTheme": {
-        "message": "Tema"
+        "message": "Theme"
     },
     "optionsThemeLight": {
-        "message": "claro"
+        "message": "light"
     },
     "optionsThemeDark": {
-        "message": "escuro"
+        "message": "dark"
     },
     "optionsToolbar": {
-        "message": "Barra de tarefas"
+        "message": "Toolbar"
     },
     "optionsToolbarPosition": {
-        "message": "Posição"
+        "message": "Position"
     },
     "optionsToolbarPositionTop": {
-        "message": "topo"
+        "message": "top"
     },
     "optionsToolbarPositionRight": {
-        "message": "direita"
+        "message": "right"
     },
     "optionsToolbarPositionBottom": {
-        "message": "baixo"
+        "message": "bottom"
     },
     "optionsToolbarPositionLeft": {
-        "message": "esquerda"
+        "message": "left"
     },
     "optionsBackup": {
-        "message": "Cópia de segurança"
+        "message": "Backup"
     },
     "optionsBackupImport": {
-        "message": "Importar"
+        "message": "Import"
     },
     "optionsBackupImportText": {
-        "message": "Cópias de segurança importadas abrirão em novas janelas e não substituirão nada.<br />Você também pode importar cópias de segurança da antiga extensão \"Grupos de Abas\"."
+        "message": "Imported backups will open in new windows and not overwrite anything.<br />You can also import backups from the old \"Tab Groups\" add-on."
     },
     "optionsBackupExport": {
-        "message": "Exportar"
+        "message": "Export"
     },
     "optionsBackupExportText": {
-        "message": "Esta seção pode se tornar obsoleta, assim que um adequado gerenciamento de sessões esteja disponível no Firefox."
+        "message": "This section might be made obsolete once proper session management is possible in Firefox."
     },
     "optionsBackupExportButton": {
-        "message": "Fazer cópia de segurança"
+        "message": "Save backup"
     },
     "optionsStatistics": {
-        "message": "Estatísticas"
+        "message": "Statistics"
     },
     "optionsStatisticsNumberOfTabs": {
-        "message": "Número de abas:"
+        "message": "Number of Tabs:"
     },
     "optionsStatisticsNumberOfTabsActive": {
-        "message": "Ativas:"
+        "message": "Active:"
     },
     "optionsStatisticsThumbnailCacheSize": {
-        "message": "Espaço em disco das minuaturas:"
+        "message": "Thumbnail Cache Size:"
     }
 }

--- a/src/_locales/pt/messages.json
+++ b/src/_locales/pt/messages.json
@@ -1,0 +1,104 @@
+{
+    "pluralRule": {
+        "message": "1"
+    },
+    "newGroupButton": {
+        "message": "Adicionar novo grupo"
+    },
+    "settingsButton": {
+        "message": "Configurações"
+    },
+    "defaultGroupName": {
+        "message": "Grupo sem nome"
+    },
+    "dragGroup": {
+        "message": "Mover grupo"
+    },
+    "closeGroup": {
+        "message": "Fechar grupo"
+    },
+    "closeGroupWarning": {
+        "message": "Fechar este grupo também fechará a aba $1. Tem certeza que deseja fechá-lo?|Fechar este grupo também fechará as abas $1. Tem certeza que deseja fechá-lo?"
+    },
+    "optionKeyboardShortcuts": {
+        "message": "Atalhos de teclado"
+    },
+    "optionKeyboardShortcutsHelpLink": {
+        "message": "https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#Key_combinations"
+    },
+    "optionKeyboardShortcutsHelpLinkText": {
+        "message": "A formatação dos atalhos de teclado estão detalhadas aqui."
+    },
+    "optionKeyboardShortcutsButtonsUpdate": {
+        "message": "Atualizar"
+    },
+    "optionKeyboardShortcutsButtonsReset": {
+        "message": "Redefinir"
+    },
+    "optionKeyboardShortcutsToggle": {
+        "message": "Alternar visão de panorama"
+    },
+    "optionKeyboardShortcutsNextGroup": {
+        "message": "Ativar o próximo Grupo de Abas"
+    },
+    "optionKeyboardShortcutsPreviousGroup": {
+        "message": "Ativar o Grupo de Abas anterior"
+    },
+    "optionsTheme": {
+        "message": "Tema"
+    },
+    "optionsThemeLight": {
+        "message": "claro"
+    },
+    "optionsThemeDark": {
+        "message": "escuro"
+    },
+    "optionsToolbar": {
+        "message": "Barra de tarefas"
+    },
+    "optionsToolbarPosition": {
+        "message": "Posição"
+    },
+    "optionsToolbarPositionTop": {
+        "message": "topo"
+    },
+    "optionsToolbarPositionRight": {
+        "message": "direita"
+    },
+    "optionsToolbarPositionBottom": {
+        "message": "baixo"
+    },
+    "optionsToolbarPositionLeft": {
+        "message": "esquerda"
+    },
+    "optionsBackup": {
+        "message": "Cópia de segurança"
+    },
+    "optionsBackupImport": {
+        "message": "Importar"
+    },
+    "optionsBackupImportText": {
+        "message": "Cópias de segurança importadas abrirão em novas janelas e não substituirão nada.<br />Você também pode importar cópias de segurança da antiga extensão \"Grupos de Abas\"."
+    },
+    "optionsBackupExport": {
+        "message": "Exportar"
+    },
+    "optionsBackupExportText": {
+        "message": "Esta seção pode se tornar obsoleta, assim que um adequado gerenciamento de sessões esteja disponível no Firefox."
+    },
+    "optionsBackupExportButton": {
+        "message": "Fazer cópia de segurança"
+    },
+    "optionsStatistics": {
+        "message": "Estatísticas"
+    },
+    "optionsStatisticsNumberOfTabs": {
+        "message": "Número de abas:"
+    },
+    "optionsStatisticsNumberOfTabsActive": {
+        "message": "Ativas:"
+    },
+    "optionsStatisticsThumbnailCacheSize": {
+        "message": "Espaço em disco das minuaturas:"
+    }
+}

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -1,6 +1,6 @@
 {
     "pluralRule": {
-        "message": "1"
+        "message": "2"
     },
     "newGroupButton": {
         "message": "Adicionar novo grupo"

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -1,0 +1,104 @@
+{
+    "pluralRule": {
+        "message": "1"
+    },
+    "newGroupButton": {
+        "message": "Adicionar novo grupo"
+    },
+    "settingsButton": {
+        "message": "Configurações"
+    },
+    "defaultGroupName": {
+        "message": "Grupo sem nome"
+    },
+    "dragGroup": {
+        "message": "Mover grupo"
+    },
+    "closeGroup": {
+        "message": "Fechar grupo"
+    },
+    "closeGroupWarning": {
+        "message": "Fechar este grupo também fechará a aba $1. Tem certeza que deseja fechá-lo?|Fechar este grupo também fechará as abas $1. Tem certeza que deseja fechá-lo?"
+    },
+    "optionKeyboardShortcuts": {
+        "message": "Atalhos de teclado"
+    },
+    "optionKeyboardShortcutsHelpLink": {
+        "message": "https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#Key_combinations"
+    },
+    "optionKeyboardShortcutsHelpLinkText": {
+        "message": "A formatação dos atalhos de teclado estão detalhadas aqui."
+    },
+    "optionKeyboardShortcutsButtonsUpdate": {
+        "message": "Atualizar"
+    },
+    "optionKeyboardShortcutsButtonsReset": {
+        "message": "Redefinir"
+    },
+    "optionKeyboardShortcutsToggle": {
+        "message": "Alternar visão de panorama"
+    },
+    "optionKeyboardShortcutsNextGroup": {
+        "message": "Ativar o próximo Grupo de Abas"
+    },
+    "optionKeyboardShortcutsPreviousGroup": {
+        "message": "Ativar o Grupo de Abas anterior"
+    },
+    "optionsTheme": {
+        "message": "Tema"
+    },
+    "optionsThemeLight": {
+        "message": "claro"
+    },
+    "optionsThemeDark": {
+        "message": "escuro"
+    },
+    "optionsToolbar": {
+        "message": "Barra de tarefas"
+    },
+    "optionsToolbarPosition": {
+        "message": "Posição"
+    },
+    "optionsToolbarPositionTop": {
+        "message": "topo"
+    },
+    "optionsToolbarPositionRight": {
+        "message": "direita"
+    },
+    "optionsToolbarPositionBottom": {
+        "message": "baixo"
+    },
+    "optionsToolbarPositionLeft": {
+        "message": "esquerda"
+    },
+    "optionsBackup": {
+        "message": "Cópia de segurança"
+    },
+    "optionsBackupImport": {
+        "message": "Importar"
+    },
+    "optionsBackupImportText": {
+        "message": "Cópias de segurança importadas abrirão em novas janelas e não substituirão nada.<br />Você também pode importar cópias de segurança da antiga extensão \"Grupos de Abas\"."
+    },
+    "optionsBackupExport": {
+        "message": "Exportar"
+    },
+    "optionsBackupExportText": {
+        "message": "Esta seção pode se tornar obsoleta, assim que um adequado gerenciamento de sessões esteja disponível no Firefox."
+    },
+    "optionsBackupExportButton": {
+        "message": "Fazer cópia de segurança"
+    },
+    "optionsStatistics": {
+        "message": "Estatísticas"
+    },
+    "optionsStatisticsNumberOfTabs": {
+        "message": "Número de abas:"
+    },
+    "optionsStatisticsNumberOfTabsActive": {
+        "message": "Ativas:"
+    },
+    "optionsStatisticsThumbnailCacheSize": {
+        "message": "Espaço em disco das minuaturas:"
+    }
+}


### PR DESCRIPTION
I don't know if the add-on will accept PT-BR latin special chars. They are all UTF-8, but I can change them to html entities/codes, hex or even unicode (Ç = &Ccedil; = &#199; = &#xc7; = U+000C7). Please just let me know if that's the case and I'll promptly change them.
Cheers