### PR TITLE
Close panorama tab when not in use

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -137,9 +137,10 @@ async function toggleView() {
                 await browser.tabs.update(tabs[1].id, {active: true});
             }
 
-            // switch to Panorama View tab
+            // Open a new Panorama View tab anyway because it's probably in the process of closing
         } else {
-            await browser.tabs.update(extTabs[0].id, {active: true});
+            openingView = true;
+            await browser.tabs.create({url: "/view.html", active: true});
         }
     } else { // if there is no Panorama View tab, make one
         openingView = true;

--- a/src/js/view/index.js
+++ b/src/js/view/index.js
@@ -141,6 +141,8 @@ async function initView() {
     document.addEventListener('visibilitychange', async function() {
         if(document.hidden) {
             browser.tabs.remove(await browser.tabs.getCurrent());
+        } else {
+            window.location.reload();
         }
     }, false);
 

--- a/src/js/view/index.js
+++ b/src/js/view/index.js
@@ -138,15 +138,9 @@ async function initView() {
         createGroup(e.clientX, e.clientY);
     }, false);
 
-    document.addEventListener('visibilitychange', function() {
+    document.addEventListener('visibilitychange', async function() {
         if(document.hidden) {
-            browser.tabs.onUpdated.removeListener(captureThumbnail);
-            //clearInterval(view.intervalId);
-        }else{
-            browser.tabs.onUpdated.addListener(captureThumbnail);
-            //view.intervalId = setInterval(captureThumbnails, 2000);
-            captureThumbnails();
-            window.location.reload();
+            browser.tabs.remove(await browser.tabs.getCurrent());
         }
     }, false);
 


### PR DESCRIPTION
With the panorama view tab getting reloaded any time it regains focus anyway, it seems like leaving it open when not visible is not really accomplishing anything besides being a bit of a performance drain (particularly with large numbers of tabs open).  Seems like the extension might as well just close the tab if it ever loses focus and just make a new one when needed.