### PR TITLE
Performance enhancements

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -219,13 +219,17 @@ async function toggleVisibleTabs(activeGroup, noTabSelected) {
     let showTabs = [];
 
     await Promise.all(tabs.map(async(tab) => {
-        let groupId = await browser.sessions.getTabValue(tab.id, 'groupId');
+        try{
+            let groupId = await browser.sessions.getTabValue(tab.id, 'groupId');
 
-        if(groupId != activeGroup) {
-            hideTabIds.push(tab.id)
-        }else{
-            showTabIds.push(tab.id)
-            showTabs.push(tab)
+            if(groupId != activeGroup) {
+                hideTabIds.push(tab.id)
+            }else{
+                showTabIds.push(tab.id)
+                showTabs.push(tab)
+            }
+        } catch {
+            //The tab has probably been closed, this should be safe to ignore
         }
     }));
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -37,7 +37,11 @@ async function getStatistics() {
 		var thumbnail = await browser.sessions.getTabValue(tab.id, 'thumbnail');
 
 		if(thumbnail) {
-			totalSize += thumbnail.length;
+			if (thumbnail.thumbnail){
+				totalSize += thumbnail.thumbnail.length;
+			} else {
+				totalSize += thumbnail.length;
+			}
 		}
 		if(!tab.discarded) {
 			numActiveTabs++;

--- a/src/js/view/groupNodes.js
+++ b/src/js/view/groupNodes.js
@@ -376,35 +376,31 @@ export async function fillGroupNodes() {
     groupNodes.pinned.content.appendChild( fragment.pinned );
 }
 
-// there is a bug in here! moving a tab to the right in the tab bar does nothing..
 export async function insertTab(tab) {
 
     var groupId = await getGroupId(tab.id);
 
-    if(groupId != -1) {
+    var tabNode = tabNodes[tab.id];
 
-        var index = 0;
+    if(groupId != -1) {
 
         var childNodes = groupNodes[groupId].content.childNodes;
 
         for(var i = 0; i < childNodes.length-1; i++) {
 
             var _tabId = Number(childNodes[i].getAttribute('tabId'));
+            if(_tabId == tab.id){
+                continue;
+            }
             var _tab = await browser.tabs.get(_tabId);
 
             if(_tab.index >= tab.index) {
-                break;
+                childNodes[i].insertAdjacentElement('beforebegin', tabNode.tab);
+                return;
             }
-            index++;
         }
 
-        var tabNode = tabNodes[tab.id];
-
-        if(index < childNodes.length-1) {
-            childNodes[index].insertAdjacentElement('beforebegin', tabNode.tab);
-        }else{
-            groupNodes[groupId].newtab.insertAdjacentElement('beforebegin', tabNode.tab);
-        }
+        groupNodes[groupId].newtab.insertAdjacentElement('beforebegin', tabNode.tab);
     }
 }
 

--- a/src/js/view/groupNodes.js
+++ b/src/js/view/groupNodes.js
@@ -369,12 +369,6 @@ export async function fillGroupNodes() {
     });
 
     groups.forEach(function(group) {
-        // When dealing with large tab groups, Firefox can sometimes become unresponsive
-        // for a bit after this call. It seems to happen when:
-        // 1.) It's during initialization of the Panorama View tab (not when fillGroupNodes()
-        //     is called afterwards).
-        // 2.) There are images in the tab. Both favicons and thumbnails cause it, but
-        //     thumbnails have a somewhat larger effect.
         groupNodes[group.id].content.insertBefore(fragment[group.id], groupNodes[group.id].newtab);
         updateGroupFit(group);
     });

--- a/src/js/view/groupNodes.js
+++ b/src/js/view/groupNodes.js
@@ -392,7 +392,7 @@ export async function fillGroupNodes() {
 
 export async function insertTab(tab) {
     if (modifyingGroupContent) {
-        setTimeout(() => fillGroupNodes(), 100);
+        setTimeout(() => insertTab(tab), 100);
     }
     try {
         modifyingGroupContent = true;

--- a/src/js/view/groupNodes.js
+++ b/src/js/view/groupNodes.js
@@ -11,11 +11,11 @@ export async function initGroupNodes(groupsNode) {
     groups.forEach(function(group) {
         groupsNode.appendChild(makeGroupNode(group));
     });
-    fillGroupNodes();
 
     groupNodes.pinned = {
         content: document.getElementById( 'pinnedTabs' ),
     };
+    fillGroupNodes();
 }
 
 function snapValue(a, b, dst) {
@@ -369,6 +369,12 @@ export async function fillGroupNodes() {
     });
 
     groups.forEach(function(group) {
+        // When dealing with large tab groups, Firefox can sometimes become unresponsive
+        // for a bit after this call. It seems to happen when:
+        // 1.) It's during initialization of the Panorama View tab (not when fillGroupNodes()
+        //     is called afterwards).
+        // 2.) There are images in the tab. Both favicons and thumbnails cause it, but
+        //     thumbnails have a somewhat larger effect.
         groupNodes[group.id].content.insertBefore(fragment[group.id], groupNodes[group.id].newtab);
         updateGroupFit(group);
     });

--- a/src/js/view/index.js
+++ b/src/js/view/index.js
@@ -33,15 +33,36 @@ browser.storage.sync.get({
     setTheme(options.theme);
     setToolbarPosition(options.toolbarPosition);
 
+    browser.storage.onChanged.addListener((changes, area)=>{
+        if("sync" == area){
+            if(changes.theme){
+                setTheme(changes.theme.newValue);
+            }
+            if(changes.toolbarPosition){
+                setToolbarPosition(changes.toolbarPosition.newValue);
+            }
+        }
+    });
+
     initView();
 });
 
 function setTheme(theme) {
-    document.getElementsByTagName("body")[0].classList.add(`theme-${theme}`);
+    replaceClass("theme", theme);
 }
 
 function setToolbarPosition(position) {
-    document.getElementsByTagName("body")[0].classList.add(`toolbar-${position}`);
+    replaceClass("toolbar", position);
+}
+
+function replaceClass(prefix, value) {
+    let classList = document.getElementsByTagName("body")[0].classList;
+    for(let klazz of classList){
+        if(klazz.startsWith(`${prefix}-`)){
+            classList.remove(klazz);
+        }
+    }
+    classList.add(`${prefix}-${value}`);
 }
 
 async function captureThumbnail(tab) {

--- a/src/js/view/index.js
+++ b/src/js/view/index.js
@@ -162,7 +162,7 @@ async function initView() {
     }, false);
 
     window.addEventListener("resize", resizeGroups);
-    document.addEventListener("keypress", keyInput);
+    document.addEventListener("keydown", keyInput);
 
     // Listen for tabs being added/removed/switched/etc. and update appropriately
     browser.tabs.onCreated.addListener(tabCreated);

--- a/src/js/view/index.js
+++ b/src/js/view/index.js
@@ -146,7 +146,6 @@ async function initView() {
             browser.tabs.onUpdated.addListener(captureThumbnail);
             //view.intervalId = setInterval(captureThumbnails, 2000);
             captureThumbnails();
-            window.location.reload();
         }
     }, false);
 

--- a/src/js/view/index.js
+++ b/src/js/view/index.js
@@ -150,10 +150,10 @@ async function initView() {
 
     document.addEventListener('visibilitychange', function() {
         if(document.hidden) {
-            browser.tabs.onUpdated.removeListener(captureThumbnail);
+            //browser.tabs.onUpdated.removeListener(captureThumbnail);
             //clearInterval(view.intervalId);
         }else{
-            browser.tabs.onUpdated.addListener(captureThumbnail);
+            //browser.tabs.onUpdated.addListener(captureThumbnail);
             //view.intervalId = setInterval(captureThumbnails, 2000);
             captureThumbnails();
         }
@@ -340,11 +340,5 @@ function tabDetached(tabId, detachInfo) {
 }
 
 async function tabActivated(activeInfo) {
-    if ( activeInfo.tabId === view.tabId ) {
-        await tabs.forEach( async function( tab ) {
-            updateThumbnail( tab.id );
-        } );
-    }
-
     setActiveTabNode(view.tabId);
 }

--- a/src/js/view/index.js
+++ b/src/js/view/index.js
@@ -149,14 +149,8 @@ async function initView() {
     }, false);
 
     document.addEventListener('visibilitychange', function() {
-        if(document.hidden) {
-            //browser.tabs.onUpdated.removeListener(captureThumbnail);
-            //clearInterval(view.intervalId);
-        }else{
+        if(!document.hidden) {
             setActiveTabNode(view.tabId);
-
-            //browser.tabs.onUpdated.addListener(captureThumbnail);
-            //view.intervalId = setInterval(captureThumbnails, 2000);
             captureThumbnails();
         }
     }, false);

--- a/src/js/view/index.js
+++ b/src/js/view/index.js
@@ -165,7 +165,20 @@ async function initView() {
     // Listen for tabs being added/removed/switched/etc. and update appropriately
     browser.tabs.onCreated.addListener(tabCreated);
     browser.tabs.onRemoved.addListener(tabRemoved);
-    browser.tabs.onUpdated.addListener(tabUpdated);
+    browser.tabs.onUpdated.addListener(tabUpdated, {
+        // This page doesn't care about tabs in other windows
+        windowId: view.windowId,
+        // We don't want to listen for every property because that includes
+        // the hidden state changing which generates a ton of events
+        // every time the active group changes
+        properties:[ 
+            "discarded",
+            "favIconUrl",
+            "pinned",
+            "title",
+            "status"
+        ]
+    });
     browser.tabs.onMoved.addListener(tabMoved);
     browser.tabs.onAttached.addListener(tabAttached);
     browser.tabs.onDetached.addListener(tabDetached);

--- a/src/js/view/index.js
+++ b/src/js/view/index.js
@@ -13,6 +13,16 @@ var view = {
     tabs: {},
 };
 
+var pendingReload = false;
+
+function queueReload(){
+    if(document.hidden){
+        pendingReload = true;
+    } else {
+        location.reload();
+    }
+}
+
 // Load settings
 browser.storage.sync.get({
     useDarkTheme: false,
@@ -171,6 +181,9 @@ async function initView() {
 
     document.addEventListener('visibilitychange', function() {
         if(!document.hidden) {
+            if(pendingReload){
+                location.reload();
+            }
             setActiveTabNode(view.tabId);
             captureThumbnails();
         }
@@ -331,6 +344,10 @@ async function tabUpdated( tabId, changeInfo, tab ) {
     updateFavicon( tab );
 
     if ( 'pinned' in changeInfo ) {
+        //FIXME for some reason the pinned tabs aren't updating reliably.
+        //putting a temporary reload trigger in until someone can figure out why that's happening
+        queueReload();
+        
         fillGroupNodes();
         updateTabNode( tab );
     }

--- a/src/js/view/index.js
+++ b/src/js/view/index.js
@@ -153,6 +153,8 @@ async function initView() {
             //browser.tabs.onUpdated.removeListener(captureThumbnail);
             //clearInterval(view.intervalId);
         }else{
+            setActiveTabNode(view.tabId);
+
             //browser.tabs.onUpdated.addListener(captureThumbnail);
             //view.intervalId = setInterval(captureThumbnails, 2000);
             captureThumbnails();
@@ -182,7 +184,6 @@ async function initView() {
     browser.tabs.onMoved.addListener(tabMoved);
     browser.tabs.onAttached.addListener(tabAttached);
     browser.tabs.onDetached.addListener(tabDetached);
-    browser.tabs.onActivated.addListener(tabActivated);
 
     view.groupsNode.addEventListener('dragover', groupDragOver, false);
     view.groupsNode.addEventListener('drop', outsideDrop, false);
@@ -337,8 +338,4 @@ function tabDetached(tabId, detachInfo) {
             updateGroupFit(group);
         });
     }
-}
-
-async function tabActivated(activeInfo) {
-    setActiveTabNode(view.tabId);
 }

--- a/src/js/view/index.js
+++ b/src/js/view/index.js
@@ -306,10 +306,8 @@ function tabRemoved(tabId, removeInfo) {
 }
 
 async function tabUpdated( tabId, changeInfo, tab ) {
-    if ( view.windowId === tab.windowId ){
-        updateTabNode( tab );
-        updateFavicon( tab );
-    }
+    updateTabNode( tab );
+    updateFavicon( tab );
 
     if ( 'pinned' in changeInfo ) {
         fillGroupNodes();

--- a/src/js/view/index.js
+++ b/src/js/view/index.js
@@ -83,7 +83,7 @@ async function captureThumbnails() {
     const tabs = browser.tabs.query({currentWindow: true, discarded: false});
 
     for(const tab of await tabs) {
-        captureThumbnail(tab); //await to lessen strain on browser
+        await captureThumbnail(tab); //await to lessen strain on browser
     }
 }
 

--- a/src/js/view/tabNodes.js
+++ b/src/js/view/tabNodes.js
@@ -156,6 +156,10 @@ export async function updateThumbnail(tabId, thumbnail) {
 	if(node) {
 		if(!thumbnail) {
 			thumbnail = await browser.sessions.getTabValue(tabId, 'thumbnail');
+			// If there's extra data there we just want the thumbnail
+			if(thumbnail && thumbnail.thumbnail){
+				thumbnail = thumbnail.thumbnail
+			}
 		}
 
 		if(thumbnail) {

--- a/src/js/view/tabNodes.js
+++ b/src/js/view/tabNodes.js
@@ -74,7 +74,7 @@ export function makeTabNode(tab) {
 	};
 }
 
-export async function updateTabNode(tab) {
+export function updateTabNode(tab) {
 
 	var node = tabNodes[tab.id];
 
@@ -130,11 +130,9 @@ export async function setActiveTabNode(tabId) {
 
 // Remove selected from all other thumbnails, add to tab with id given
 export async function setActiveTabNodeById(tabId) {
-    await forEachTab(async function(tab) {
-        if (tabNodes[tab.id]) {
-            tabNodes[tab.id].tab.classList.remove('selected');
-        }
-    });
+	for(var tabNode in tabNodes){
+		tabNode.tab.classList.remove('selected')
+	}
     tabNodes[tabId].tab.classList.add('selected');
     activeTabId = tabId;
 }

--- a/src/js/view/tabNodes.js
+++ b/src/js/view/tabNodes.js
@@ -1,4 +1,4 @@
-import { forEachTab } from './tabs.js';
+import { forEachTab, forEachTabSync } from './tabs.js';
 import { tabDragStart, tabDragEnter, tabDragOver, tabDragLeave, tabDrop, tabDragEnd } from './drag.js';
 import { new_element } from './utils.js';
 
@@ -14,8 +14,8 @@ export async function initTabNodes(tabId) {
 	await forEachTab(async function(tab) {
 		makeTabNode(tab);
 		updateTabNode(tab);
-		updateFavicon(tab);
-		updateThumbnail(tab.id);
+		await updateFavicon(tab);
+		await updateThumbnail(tab.id);
 	});
 	setActiveTabNode(tabId);
 }
@@ -109,7 +109,7 @@ export async function setActiveTabNode(tabId) {
 	var lastActive = -1;
 	var lastAccessed = 0;
 
-	await forEachTab(async function(tab) {
+	await forEachTabSync(function(tab) {
 
 		// Can race if deleteTabNode is called at the same time (e.g. every time
 		// the active tab is closed, since a new tab becomes active), so confirm
@@ -168,6 +168,8 @@ export async function updateThumbnail(tabId, thumbnail) {
 	}
 }
 
+// This function is a pretty big hot spot on initialization.  Testing the image
+// like this appears to be very expensive
 async function testImage(url) {
 	return new Promise(function (resolve, reject) {
 
@@ -193,15 +195,14 @@ export async function updateFavicon(tab) {
 		if(tab.favIconUrl &&
 			tab.favIconUrl.substr(0, 22) != 'chrome://mozapps/skin/' &&
 			tab.favIconUrl != tab.url) {
-			testImage(tab.favIconUrl).then(
-				_ => {
-					node.favicon.style.backgroundImage = 'url(' + tab.favIconUrl + ')';
-					node.favicon.classList.add('visible');
-				}, _ => {
-					node.favicon.style.backgroundImage = '';
-					node.favicon.classList.remove('visible');
-				}
-			);
+			try{
+				await testImage(tab.favIconUrl);
+				node.favicon.style.backgroundImage = 'url(' + tab.favIconUrl + ')';
+				node.favicon.classList.add('visible');
+			} catch {
+				node.favicon.style.backgroundImage = '';
+				node.favicon.classList.remove('visible');
+			}
 		}else{
 			node.favicon.classList.remove('visible');
 		}

--- a/src/js/view/tabNodes.js
+++ b/src/js/view/tabNodes.js
@@ -130,8 +130,8 @@ export async function setActiveTabNode(tabId) {
 
 // Remove selected from all other thumbnails, add to tab with id given
 export async function setActiveTabNodeById(tabId) {
-	for(var tabNode in tabNodes){
-		tabNode.tab.classList.remove('selected')
+	for(var nodeId in tabNodes){
+		tabNodes[nodeId].tab.classList.remove('selected')
 	}
     tabNodes[tabId].tab.classList.add('selected');
     activeTabId = tabId;

--- a/src/js/view/tabNodes.js
+++ b/src/js/view/tabNodes.js
@@ -129,7 +129,7 @@ export async function setActiveTabNode(tabId) {
 }
 
 // Remove selected from all other thumbnails, add to tab with id given
-export async function setActiveTabNodeById(tabId) {
+export function setActiveTabNodeById(tabId) {
 	for(var nodeId in tabNodes){
 		tabNodes[nodeId].tab.classList.remove('selected')
 	}

--- a/src/js/view/tabNodes.js
+++ b/src/js/view/tabNodes.js
@@ -168,8 +168,10 @@ export async function updateThumbnail(tabId, thumbnail) {
 	}
 }
 
-// This function is a pretty big hot spot on initialization.  Testing the image
-// like this appears to be very expensive
+// This testing mechanism can seemingly hit a slow path in Firefox related 
+// to webRequest listeners.  If we're spending a lot of time in here, it's
+// probably because another extension registered one ot those listeners
+// on the Panorama tab
 async function testImage(url) {
 	return new Promise(function (resolve, reject) {
 

--- a/src/js/view/tabs.js
+++ b/src/js/view/tabs.js
@@ -8,7 +8,7 @@ export async function getGroupId(tabId) {
 };
 
 export async function forEachTab(callback) {
-	const tabs = await browser.tabs.query({currentWindow: true});
+	const tabs = await getAllTabsInWindow();
 	for(const tab of tabs){
 		await callback(tab);
 	}
@@ -16,8 +16,13 @@ export async function forEachTab(callback) {
 
 
 export async function forEachTabSync(callback) {
-	const tabs = await browser.tabs.query({currentWindow: true});
+	const tabs = await getAllTabsInWindow();
 	for(const tab of tabs){
 		callback(tab);
 	}
 };
+
+
+export async function getAllTabsInWindow(){
+	return await browser.tabs.query({currentWindow: true});
+}

--- a/src/js/view/tabs.js
+++ b/src/js/view/tabs.js
@@ -9,6 +9,15 @@ export async function getGroupId(tabId) {
 
 export async function forEachTab(callback) {
 	const tabs = await browser.tabs.query({currentWindow: true});
+	for(const tab of tabs){
+		await callback(tab);
+	}
+};
 
-	await Promise.all(tabs.map(callback));
+
+export async function forEachTabSync(callback) {
+	const tabs = await browser.tabs.query({currentWindow: true});
+	for(const tab of tabs){
+		callback(tab);
+	}
 };


### PR DESCRIPTION
This Pull Request contains several attempts to improve the performance of this extension. The highlights include:
- No longer reloading the Panorama View tab every time it comes back into view.
- Fixed some bugs that would cause the tab order to desync in the Panorama View. ~TODO: Just found another ordering bug while typing this, going to submit as a draft anyway because this should be ready for review aside from that.~
- Filtered out `tabs.onUpdated` events that the extension doesn't need to do anything with (this combined with not reloading the Panorama View every time should address #53 in most, but not quite all cases)
- Refactored how the thumbnails are captured so that the cached version is reused if the tab hasn't been accessed since it was captured

Areas still potentially in need of improvement:
- Capturing thumbnails is still exactly as expensive as it was before, it just needs to happen a lot less now.
- ~Initializing a new Panorama view tab is still slow with large groups.  There seem to be two distinct causes of this:~
  - ~Testing the favicons appears to be a very expensive process.~
  - ~Adding the tabs to the DOM is inexplicably expensive unless you remove all images from it.  Disabling thumbnails entirely would help a bit, but even favicons seem to be enough to cause some amount of a delay (At least for my 3 groups with \~250, 10, and 27 tabs, respectively).~

EDIT: The poor initialization performance seems to have been a bad interaction between this extension and another one called Decentraleyes.  Whatever is happening there is probably a bug in Firefox itself and there doesn't seem to be much that could be done here to mitigate it outside of just disabling all the images.  This was also definitely exacerbating the screenshot slowness.  