### PR TITLE
Fix for import from old Tab Groups backup

### DIFF
--- a/src/js/backup.js
+++ b/src/js/backup.js
@@ -29,8 +29,12 @@ function convertBackup(tgData) {
 			var tab = tgData.windows[wi].tabs[ti];
 			if(tab.pinned == true) {
 				var groupId = 0;
-			}else{
+			}else if(tab.extData) {
 				var groupId = JSON.parse(tab.extData['tabview-tab']).groupID;
+			}else{
+				// No associated groupId, where should it go???
+				console.log("Skipping tab with missing groupId: "+tab.entries[0].url);
+				continue;
 			}
 			data.windows[wi].tabs.push({
 				url: tab.entries[0].url,


### PR DESCRIPTION
Not sure if its a bug in the old extension, but I have a backup where some of the tabs were missing the extData attribute which contains the group id.  This would cause the import PTG to crash.  I've fixed this by having PTG discard all such tabs and log a message because its not clear where such a tab should go.  I don't think this is a common issue, but a quick fix to allow me to get my old backup imported.
