### PR TITLE
Use window size & position data from old extension backup file.

### DIFF
--- a/src/js/backup.js
+++ b/src/js/backup.js
@@ -14,7 +14,13 @@ function convertBackup(tgData) {
 		const tabviewGroup = JSON.parse(tgData.windows[wi].extData['tabview-group']);
 		const tabviewGroups = JSON.parse(tgData.windows[wi].extData['tabview-groups']);
 
-		data.windows[wi] = {groups: [], tabs: [], activeGroup: tabviewGroups.activeGroupId, groupIndex: tabviewGroups.nextID};
+		data.windows[wi] = {groups: [], tabs: [], activeGroup: tabviewGroups.activeGroupId, groupIndex: tabviewGroups.nextID, position: {}};
+		data.windows[wi].position = {
+			left: tgData.windows[wi].screenX,
+			top: tgData.windows[wi].screenY,
+			height: tgData.windows[wi].height,
+			width: tgData.windows[wi].width
+		};
 
 		for(const gkey in tabviewGroup) {
 			data.windows[wi].groups.push({
@@ -101,7 +107,12 @@ async function openBackup(data) {
 			});
 		}
 
+		let windata = {};
+		if (data.windows[wi].position) {
+			windata = data.windows[wi].position;
+		}
 		const window = await browser.windows.create({});
+		await browser.windows.update(window.id, windata);
 
 		await browser.sessions.setWindowValue(window.id, 'groups', groups);
 		await browser.sessions.setWindowValue(window.id, 'activeGroup', data.windows[wi].activeGroup);


### PR DESCRIPTION
This change attempts to create windows with a size and position specified in the old extension backup file.  I say "_attempt_" because in my testing its not creating the exact same size and position.  It appears to be noticeably off (a very rough approximation), but much closer to the original window than before the change (which is nothing like the shape of the older window).

Crazily it appears as though the two firefoxs I'm using to test this (FF66 and FF51) have different ideas of what pixel size is.  FF51 shows its width in pixels as being less than FF66, however FF51 is visually wider than FF66.  I think this is good enough for now.