### PR TITLE
Raise group to foreground when clicking in group content area.

### DIFF
--- a/src/js/view/groupNodes.js
+++ b/src/js/view/groupNodes.js
@@ -229,10 +229,6 @@ export function makeGroupNode(group) {
         closeGroup(content, group);
     }, false);
 
-    content.addEventListener('click', function(event) {
-        event.stopPropagation();
-    }, false);
-
     newtab.addEventListener('click', async function(event) {
         event.stopPropagation();
         await groups.setActive(group.id);
@@ -501,6 +497,12 @@ export function resizeGroups(groupId, groupRect) {
 
         updateGroupFit(group);
     });
+}
+
+export function raiseGroup(groupId) {
+    let lastMoved = (new Date).getTime();
+    groups.get(groupId).lastMoved = lastMoved;
+    groupNodes[groupId].group.style.zIndex = lastMoved.toString().substr(-9);
 }
 
 function getFit(param) {

--- a/src/js/view/index.js
+++ b/src/js/view/index.js
@@ -1,6 +1,6 @@
 import { getGroupId } from './tabs.js';
 import { tabMoved, groupDragOver, outsideDrop, createDragIndicator } from './drag.js';
-import { groupNodes, initGroupNodes, closeGroup, makeGroupNode, fillGroupNodes, insertTab, resizeGroups, updateGroupFit } from './groupNodes.js';
+import { groupNodes, initGroupNodes, closeGroup, makeGroupNode, fillGroupNodes, insertTab, resizeGroups, raiseGroup, updateGroupFit } from './groupNodes.js';
 import { initTabNodes, makeTabNode, updateTabNode, setActiveTabNode, setActiveTabNodeById, getActiveTabId, deleteTabNode, updateThumbnail, updateFavicon } from './tabNodes.js';
 import * as groups from './groups.js';
 
@@ -130,6 +130,14 @@ async function doubleClick(e) {
     }
 }
 
+async function singleClick(e) {
+    if (e.target.className === "content transition") {
+        var groupID = e.target.getAttribute("groupid");
+        raiseGroup(groupID);
+    }
+    event.stopPropagation();
+}
+
 /**
  * Initialize the Panorama View tab
  *
@@ -216,6 +224,7 @@ async function initView() {
     view.groupsNode.addEventListener('dragover', groupDragOver, false);
     view.groupsNode.addEventListener('drop', outsideDrop, false);
     view.groupsNode.addEventListener('dblclick', doubleClick, false);
+    view.groupsNode.addEventListener('click', singleClick, false);
 }
 
 async function keyInput(e) {


### PR DESCRIPTION
When clicking in a group, but not on a tab inside the group the group will be raised.  This is helpful for groups which are partially occluded which you want to see fully.  Ideally a single click on the header would also raise the group, but I've had trouble catching a click event to the header.