### PR TITLE
Fix create group on 2nd empty window

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -350,8 +350,8 @@ async function createGroupInWindow(browserWindow) {
         lastMoved: (new Date).getTime(),
     }];
 
-    await browser.sessions.setWindowValue(window.id, 'groups', groups);
-    await browser.sessions.setWindowValue(window.id, 'activeGroup', groupId);
+    await browser.sessions.setWindowValue(browserWindow.id, 'groups', groups);
+    await browser.sessions.setWindowValue(browserWindow.id, 'activeGroup', groupId);
 }
 
 /** Put any tabs that do not have a group into the active group */

--- a/src/js/view/groups.js
+++ b/src/js/view/groups.js
@@ -1,5 +1,5 @@
-var windowId;
-var groups;
+let windowId;
+let groups;
 
 async function save() {
 	await browser.sessions.setWindowValue(windowId, 'groups', groups);
@@ -28,7 +28,7 @@ function getIndex(id) {
 export async function init() {
 
 	windowId = (await browser.windows.getCurrent()).id;
-	groups = (await browser.sessions.getWindowValue(windowId, 'groups'));
+	groups = (await browser.sessions.getWindowValue(windowId, 'groups')) || [];
 
 	for(var i in groups) {
 		groups[i].tabCount = 0;


### PR DESCRIPTION
I've recorded two videos. 

Showcase the bug (before.mp4) and showcase the bugfix (after.mp4).
[Videos.zip](https://github.com/projectdelphai/panorama-tab-groups/files/3526654/Videos.zip)

EDIT:
And after recording the videos I found a regression from early merges. In new windows, PTG previously create the first empty group.
This is also fixed in this PR.