### PR TITLE
Proof of Concept: Swap panorama icons to popup style theming

### DIFF
--- a/src/_locales/el_GR/messages.json
+++ b/src/_locales/el_GR/messages.json
@@ -1,0 +1,149 @@
+{
+    "pluralRule": {
+        "message": "1"
+    },
+    "newGroupButton": {
+        "message": "Προσθήκη νέου γκρουπ"
+    },
+    "freeformButton": {
+        "message": "Ελεύθερη ευθυγράμμιση"
+    },
+    "tilingButton": {
+        "message": "Αυτόματη (ψηφιδωτή) ευθυγράμμιση"
+    },
+    "settingsButton": {
+        "message": "Ρυθμίσεις"
+    },
+    "defaultGroupName": {
+        "message": "Ανώνυμο γκρουπ"
+    },
+    "dragGroup": {
+        "message": "Μετακίνηση γκρουπ"
+    },
+    "closeGroup": {
+        "message": "Κλείσιμο γκρουπ"
+    },
+    "closeGroupWarning": {
+        "message": "Με το κλείσιμο αυτού του γκρουπ, θα χαθεί και η καρτέλα $1 μαζί. Είστε σίγουροι για αυτό;|Με το κλείσιμο αυτού του γκρουπ, θα χαθούν και οι καρτέλες $1 μαζί. Είστε σίγουροι για αυτό;"
+    },
+    "closeTab": {
+        "message": "Κλείσιμο καρτέλας"
+    },
+    "openNewTab": {
+        "message": "Άνοιγμα νέας καρτέλας"
+    },
+    "tabCount": {
+        "message": "$1 καρτέλα|$1 καρτέλες"
+    },
+    "searchForTab.placeholder": {
+        "message": "Αναζήτηση καρτέλας..."
+    },
+    "searchForTab.noResults": {
+        "message": "Δε βρέθηκαν καρτέλες"
+    },
+    "goBackToGroups": {
+        "message": "Επιστροφή στα γκρουπ"
+    },
+    "optionKeyboardShortcuts": {
+        "message": "Συντομεύσεις πληκτρολογίου"
+    },
+    "optionKeyboardShortcutsHelpLink": {
+        "message": "https://developer.mozilla.org/el/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#Key_combinations"
+    },
+    "optionKeyboardShortcutsHelpLinkText": {
+        "message": "The format for the shortcut option is detailed here."
+    },
+    "optionKeyboardShortcutsButtonsUpdate": {
+        "message": "Ενημέρωση"
+    },
+    "optionKeyboardShortcutsButtonsReset": {
+        "message": "Επαναφορά"
+    },
+    "optionKeyboardShortcutsButtonsDisable": {
+        "message": "Απενεργοποίηση"
+    },
+    "optionKeyboardShortcutsButtonsEnable": {
+        "message": "Ενεργοποίηση"
+    },
+    "optionKeyboardShortcutsToggle": {
+        "message": "Εναλλαγή σε Προβολή Panorama"
+    },
+    "optionKeyboardShortcutsNextGroup": {
+        "message": "Ενεργοποίηση του επόμενου Γκρουπ Καρτελών"
+    },
+    "optionKeyboardShortcutsPreviousGroup": {
+        "message": "Ενεργοποίηση του επόμενου Γκρουπ Καρτελών"
+    },
+    "optionsView": {
+        "message": "Προβολή"
+    },
+    "optionsViewFreeform": {
+        "message": "Ελεύθερη (κλασσική)"
+    },
+    "optionsViewPopup": {
+        "message": "Εικόνα εντός εικόνας (Popup)"
+    },
+    "optionsTheme": {
+        "message": "Θέμα"
+    },
+    "optionsThemeLight": {
+        "message": "ανοιχτό"
+    },
+    "optionsThemeDark": {
+        "message": "σκούρο"
+    },
+    "optionsToolbar": {
+        "message": "Γραμμή Εργαλείων"
+    },
+    "optionsToolbarPosition": {
+        "message": "Θέση"
+    },
+    "optionsToolbarPositionTop": {
+        "message": "πάνω"
+    },
+    "optionsToolbarPositionRight": {
+        "message": "δεξιά"
+    },
+    "optionsToolbarPositionBottom": {
+        "message": "κάτω"
+    },
+    "optionsToolbarPositionLeft": {
+        "message": "αριστερά"
+    },
+    "optionsBackup": {
+        "message": "Αντίγραφο Ασφαλείας"
+    },
+    "optionsBackupImport": {
+        "message": "Εισαγωγή"
+    },
+    "optionsBackupImportText": {
+        "message": "Τα εισαγόμενα αντίγραφα ασφαλείας θα ανοίξουν σε νέα παράθυρα και δε θα αντικαταστήσουν κάτι.<br />Μπορείτε επίσης να εισάγετε αντίγραφα ασφαλείας από το παλιό πρόσθετο \"Tab Groups\"."
+    },
+    "optionsBackupExport": {
+        "message": "Εξαγωγή"
+    },
+    "optionsBackupExportText": {
+        "message": "Αυτό το τμήμα ίσως καταστεί παρωχημένο όταν μια πρέπουσα διαχείριση συνεδρίας είναι δυνατή στο Firefox."
+    },
+    "optionsBackupExportButton": {
+        "message": "Αποθήκευση αντιγράφου ασφαλείας"
+    },
+    "optionsStatistics": {
+        "message": "Στατιστικά"
+    },
+    "optionsStatisticsNumberOfTabs": {
+        "message": "Αριθμός Καρτελών:"
+    },
+    "optionsStatisticsNumberOfTabsActive": {
+        "message": "Ενεργές:"
+    },
+    "optionsStatisticsThumbnailCacheSize": {
+        "message": "Μέγεθος Προσωρινής Μνήμης Thumbnail:"
+    },
+    "refreshGroups": {
+        "message": "Ανανέωση των Γκρουπ"
+    },
+    "sendTab": {
+        "message": "Αποστολή σε Γκρουπ"
+    }
+}

--- a/src/_locales/fr_FR/messages.json
+++ b/src/_locales/fr_FR/messages.json
@@ -5,6 +5,12 @@
     "newGroupButton": {
         "message": "Ajouter un nouveau groupe"
     },
+    "freeformButton": {
+        "message": "Alignement de forme libre"
+    },
+    "tilingButton": {
+        "message": "Alignement (tuiles) automatique"
+    },
     "settingsButton": {
         "message": "Réglages"
     },
@@ -18,7 +24,25 @@
         "message": "Fermer le groupe"
     },
     "closeGroupWarning": {
-        "message": "La fermeture de ce groupe fermera $1 onglet à l'intérieur de celui-ci. Êtes-vous sûr de vouloir faire ça ?`|La fermeture de ce groupe fermera $1 onglets à l'intérieur de celui-ci. Êtes-vous sûr de vouloir faire ça ?`"
+        "message": "La fermeture de ce groupe fermera $1 onglet à l'intérieur de celui-ci. Êtes-vous sûr de vouloir faire ça ?|La fermeture de ce groupe fermera $1 onglets à l'intérieur de celui-ci. Êtes-vous sûr de vouloir faire ça ?"
+    },
+    "closeTab": {
+        "message": "Fermer l'onglet"
+    },
+    "openNewTab": {
+        "message": "Ouvrir un nouvel onglet"
+    },
+    "tabCount": {
+        "message": "$1 onglet|$1 onglets"
+    },
+    "searchForTab.placeholder": {
+        "message": "Rechercher un onglet..."
+    },
+    "searchForTab.noResults": {
+        "message": "Aucun onglet trouvé"
+    },
+    "goBackToGroups": {
+        "message": "Retour aux groupes"
     },
     "optionKeyboardShortcuts": {
         "message": "Raccourcis clavier"
@@ -35,6 +59,12 @@
     "optionKeyboardShortcutsButtonsReset": {
         "message": "Réinitialiser"
     },
+    "optionKeyboardShortcutsButtonsDisable": {
+        "message": "Désactiver"
+    },
+    "optionKeyboardShortcutsButtonsEnable": {
+        "message": "Activer"
+    },
     "optionKeyboardShortcutsToggle": {
         "message": "Basculer vers Panorama View"
     },
@@ -43,6 +73,15 @@
     },
     "optionKeyboardShortcutsPreviousGroup": {
         "message": "Activer le Groupe d'onglets précédent"
+    },
+    "optionsView": {
+        "message": "Vue"
+    },
+    "optionsViewFreeform": {
+        "message": "Forme libre (classique)"
+    },
+    "optionsViewPopup": {
+        "message": "Popup"
     },
     "optionsTheme": {
         "message": "Thème"
@@ -93,13 +132,13 @@
         "message": "Statistiques"
     },
     "optionsStatisticsNumberOfTabs": {
-        "message": "Nombre d'onglets:"
+        "message": "Nombre d'onglets :"
     },
     "optionsStatisticsNumberOfTabsActive": {
-        "message": "Actif:"
+        "message": "Actif :"
     },
     "optionsStatisticsThumbnailCacheSize": {
-        "message": "Taille du cache des miniatures:"
+        "message": "Taille du cache des miniatures :"
     },
     "refreshGroups": {
         "message": "Actualiser les groupes"

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -5,11 +5,17 @@
     "newGroupButton": {
         "message": "Новая группа"
     },
+    "freeformButton": {
+        "message": "Свободное положение групп"
+    },
+    "tilingButton": {
+        "message": "Выровнять по сетке"
+    },
     "settingsButton": {
         "message": "Настройки"
     },
     "defaultGroupName": {
-        "message": "Группа без названия"
+        "message": "Безымянная группа"
     },
     "dragGroup": {
         "message": "Переместить"
@@ -20,8 +26,26 @@
     "closeGroupWarning": {
         "message": "Закрывая эту группу, вы закроете $1 вкладку в ней. Вы уверенны что хотите этого?|Закрывая эту группу, вы закроете $1 вкладки в ней. Вы уверенны что хотите этого?|Закрывая эту группу, вы закроете $1 вкладок в ней. Вы уверенны что хотите этого?"
     },
+    "closeTab": {
+        "message": "Закрыть вкладку"
+    },
+    "openNewTab": {
+        "message": "Открыть новую вкладку"
+    },
+    "tabCount": {
+        "message": "$1 вкладка|$1 вкладки|$1 вкладок"
+    },
+    "searchForTab.placeholder": {
+        "message": "Поиск вкладки..."
+    },
+    "searchForTab.noResults": {
+        "message": "Вкладка не найдена"
+    },
+    "goBackToGroups": {
+        "message": "Вернуться к группам"
+    },
     "optionKeyboardShortcuts": {
-        "message": "Сочетания клавиш"
+        "message": "Комбинации клавиш"
     },
     "optionKeyboardShortcutsHelpLink": {
         "message": "https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#Key_combinations"
@@ -35,14 +59,29 @@
     "optionKeyboardShortcutsButtonsReset": {
         "message": "Сброс"
     },
+    "optionKeyboardShortcutsButtonsDisable": {
+        "message": "Отключить"
+    },
+    "optionKeyboardShortcutsButtonsEnable": {
+        "message": "Включить"
+    },
     "optionKeyboardShortcutsToggle": {
-        "message": "Просмотр в режиме панорамы"
+        "message": "Открыть панораму"
     },
     "optionKeyboardShortcutsNextGroup": {
         "message": "Выбрать следующую группу вкладок"
     },
     "optionKeyboardShortcutsPreviousGroup": {
         "message": "Выбрать предыдущую группу вкладок"
+    },
+    "optionsView": {
+        "message": "Тип представления"
+    },
+    "optionsViewFreeform": {
+        "message": "Панорама (классическая)"
+    },
+    "optionsViewPopup": {
+        "message": "Выпадающее меню"
     },
     "optionsTheme": {
         "message": "Тема оформления"
@@ -57,7 +96,7 @@
         "message": "Панель инструментов"
     },
     "optionsToolbarPosition": {
-      "message": "Положение"
+        "message": "Положение"
     },
     "optionsToolbarPositionTop": {
         "message": "сверху"
@@ -102,9 +141,9 @@
         "message": "Размер кэша миниатюр:"
     },
     "refreshGroups": {
-        "message": "Переместить в группу"
+        "message": "Обновить список групп"
     },
     "sendTab": {
-        "message": "Обновить список групп"
+        "message": "Переместить в группу"
     }
 }

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -317,7 +317,7 @@ async function setActionTitle(windowId, activeGroup = null) {
     }
     browser.browserAction.setTitle({title: `Active Group: ${name}`, 'windowId': windowId});
     browser.browserAction.setBadgeText({text: String(groups.length), windowId: windowId});
-    browser.browserAction.setBadgeBackgrounColor({color: "#666666"});
+    browser.browserAction.setBadgeBackgroundColor({color: "#666666"});
 }
 
 /** Make sure each window has a group */


### PR DESCRIPTION
Some of the icons (freeform and tiling) didn't swap with the dark mode theme. I looked to see how the popup view was doing its theme switching and it seems like a nice approach. This proof of concept is to show that minor, non-breaking changes can make the original panorama view operate in the same manner.

Welcome opinions and/or feedback.

- Using the ::before option and svg masks as illustrated in the popup option new icons do not have to be generated per theme.
- The first two icons are sourced from the _shared/icons folder and match their popup view counterparts, the last two are sourced from the original icons folder as examples of both shared and independent elements. 
- May require small visual tweaks and could benefit from a cleanup of the icon system in general if implemented.  

Possible Regression: The window does not switch back to the previous tab group when clicking on the settings button. Unsure if this is from the changes made here or to the main branch - after checking this is affecting the main branch (at least on my machine) as well and may be intended.