### PR TITLE
Toggle group by num key

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -545,4 +545,6 @@ function onRuntimeInstallNotification(details) {
 
 browser.runtime.onInstalled.addListener(onRuntimeInstallNotification);
 
-
+export async function switchToGroup(groupId, noTabSelected) {
+    await toggleVisibleTabs(groupId, noTabSelected);
+}

--- a/src/js/view/index.js
+++ b/src/js/view/index.js
@@ -2,7 +2,7 @@ import { getGroupId } from './tabs.js';
 import { tabMoved, groupDragOver, outsideDrop, createDragIndicator } from './drag.js';
 import { groupNodes, initGroupNodes, closeGroup, makeGroupNode, fillGroupNodes, insertTab, resizeGroups, raiseGroup, updateGroupFit } from './groupNodes.js';
 import { initTabNodes, makeTabNode, updateTabNode, setActiveTabNode, setActiveTabNodeById, getActiveTabId, deleteTabNode, updateThumbnail, updateFavicon } from './tabNodes.js';
-import { toggleVisibleTabs } from '../background.js';
+import { switchToGroup } from '../background.js';
 import * as groups from './groups.js';
 
 var view = {
@@ -410,7 +410,7 @@ async function keyInput(e) {
         // if we have a keylogged groupID then raiseGroup
         console.log('Enter ' + view.loggedNumericKeys);
         if (view.loggedNumericKeys != '') {
-            await toggleVisibleTabs(view.loggedNumericKeys, true);
+            await switchToGroup(view.loggedNumericKeys, true);
         } else {
             console.log('activate ' + view.loggedNumericKeys);
             // activate selected tab

--- a/src/js/view/index.js
+++ b/src/js/view/index.js
@@ -404,21 +404,18 @@ async function keyInput(e) {
     } else if (charList.indexOf(e.key) > -1) {
         // log numeric inputs
         view.loggedNumericKeys += e.key;
-        console.log(view.loggedNumericKeys + '.');
         e.stopPropagation();
     } else if (e.key === "Enter") {
         // if we have a keylogged groupID then raiseGroup
-        console.log('Enter ' + view.loggedNumericKeys);
         if (view.loggedNumericKeys != '') {
             await switchToGroup(view.loggedNumericKeys, true);
         } else {
-            console.log('activate ' + view.loggedNumericKeys);
             // activate selected tab
             browser.tabs.update(getActiveTabId(), {active: true});
         }
         view.loggedNumericKeys='';
     } else {
-      console.log('reset num key');
+      // reset numkey logging
       view.loggedNumericKeys = '';
     }
 }


### PR DESCRIPTION
Enable the user to switch to another group by just typing the numeric groupID and confirming with "Enter" when the overview is open. 

Used the existing keydown-handler.

An example use with shortcuts could be: 

1. [Alt] + [Shift] + [F] -> switch to view mode
2. [3] -> we want to change to group 3
3. [Enter]
4. Et voilá: Group 3 will be displayed.

Should also work for groupIDs >=10, as i added a simple key logging to record numeric keypresses.
The numeric input will not be displayed on screen

