### PR TITLE
Prevent the tab group view from generating thumbnails of itself.

### DIFF
--- a/src/js/view/index.js
+++ b/src/js/view/index.js
@@ -82,6 +82,8 @@ async function setLayoutMode(mode) {
 }
 
 async function captureThumbnail(tab) {
+  if(tab.url.startsWith(browser.extension.getURL('view.html'))) return; // No selfies
+
   const tabId = tab.id;
 
   const cachedThumbnail = await browser.sessions.getTabValue(tabId, 'thumbnail');


### PR DESCRIPTION
Fixes #260

Capturing the tab group view containing a large number of tabs can result in a non-insignificant period where the user can't interact with the browser.